### PR TITLE
Fix count parameter in trans() available since Symfony 4.2

### DIFF
--- a/Twig/Extension/TranslationExtension.php
+++ b/Twig/Extension/TranslationExtension.php
@@ -42,7 +42,7 @@ class TranslationExtension extends BaseTranslationExtension
         $this->localeManager = $localeManager;
     }
 
-    public function trans($message, array $arguments = array(), $domain = null, $locale = null)
+    public function trans($message, array $arguments = array(), $domain = null, $locale = null, $count = null)
     {
         $this->validateTranslation($message, $domain, $locale);
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "tillackt/lexik-translation-sonata-bundle",
+  "name": "pix-art/lexik-translation-sonata-bundle",
   "description": "A Sonata bundle to create a lexik translation admin interface",
   "keywords": [
     "translations", "sonata"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "pix-art/lexik-translation-sonata-bundle",
+  "name": "tillackt/lexik-translation-sonata-bundle",
   "description": "A Sonata bundle to create a lexik translation admin interface",
   "keywords": [
     "translations", "sonata"


### PR DESCRIPTION
Hi,

old code throws an error since Symfony 4.2:

> Warning: Declaration of LexikTranslationSonataBundle\Twig\Extension\TranslationExtension::trans($message, array $arguments = Array, $domain = NULL, $locale = NULL) should be compatible with Symfony\Bridge\Twig\Extension\TranslationExtension::trans($message, array $arguments = Array, $domain = NULL, $locale = NULL, $count = NULL)

Please merge this Pull Request.

Thank you!